### PR TITLE
ovirt-engine-hyper-upgrade: Add missing repo for 4.1 repos

### DIFF
--- a/src/ovirt-engine-hyper-upgrade
+++ b/src/ovirt-engine-hyper-upgrade
@@ -161,6 +161,7 @@ class Subscriptions(Base):
         "rhel-7-server-supplementary-rpms",
         "rhel-7-server-rpms",
         "rhel-7-server-rhv-4.1-rpms",
+        "rhel-7-server-rhv-4-tools-rpms",
         "jb-eap-7-for-rhel-7-server-rpms"
     ]
 


### PR DESCRIPTION
rhel-7-server-rhv-4-tools-rpms was missing for 4.1, according with
https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.1/html/installation_guide/chap-installing_red_hat_enterprise_virtualization#Subscribing_to_the_Red_Hat_Enterprise_Virtualization_Manager_Channels_using_Subscription_Manager

Issue: https://github.com/oVirt/ovirt-engine-hyper-upgrade/issues/2